### PR TITLE
Add terminology bindings for data elements, value set logical definitions

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -386,10 +386,11 @@ function fillElementLines(dataElementLines, profileLines, vsMap, de, specs, conf
         const cardInfo = getCardinalityInfo(card);
         const dataType = getDataType(de, rule.path, specs, endOfPathElement);
         const vsInfo = getVsInfo(de, rule.path, specs, config.projectURL);
+        const binding = vsInfo ? 'Value Set' : '';
         const url = vsInfo ? vsInfo.url : '';
         const strength = vsInfo ? vsInfo.strength.toLowerCase() : '';
         const unit = getUnit(de, rule.path, specs, config.projectURL);
-        dataElementLines.push([profileName, pathName, description, cardInfo.requirement, cardInfo.multiplicity, dataType, 'Value Set', '', '', '', url, strength, unit]);
+        dataElementLines.push([profileName, pathName, description, cardInfo.requirement, cardInfo.multiplicity, dataType, binding, '', '', '', url, strength, unit]);
         if (vsInfo) {
           vsMap.set(vsInfo.url, vsInfo.vs);
         }
@@ -409,9 +410,9 @@ function fillValueSetLines(vs, valueSetLines, valueSetDetailsLines) {
     valueSetDetailsLines.push([
       vs.identifier.name,
       system,
+      '',
       `${rule.code.code}`,
-      `${rule.code.display}`,
-      ''
+      `${rule.code.display}`
     ]);
     codeSystems.add(system);
   }
@@ -420,9 +421,9 @@ function fillValueSetLines(vs, valueSetLines, valueSetDetailsLines) {
     valueSetDetailsLines.push([
       vs.identifier.name,
       system,
+      `includes codes descending from ${rule.code.code} | ${rule.code.display}`,
       '',
-      '',
-      `includes codes descending from ${rule.code.code} | ${rule.code.display}`
+      ''
     ]);
     codeSystems.add(system);
   }
@@ -430,9 +431,9 @@ function fillValueSetLines(vs, valueSetLines, valueSetDetailsLines) {
     valueSetDetailsLines.push([
       vs.identifier.name,
       system,
+      `includes codes from code ${rule.code.code} | ${rule.code.display}`,
       '',
-      '',
-      `includes codes from code ${rule.code.code} | ${rule.code.display}`
+      ''
     ]);
     codeSystems.add(system);
   }
@@ -441,9 +442,9 @@ function fillValueSetLines(vs, valueSetLines, valueSetDetailsLines) {
     valueSetDetailsLines.push([
       vs.identifier.name,
       system,
+      `includes codes from code system ${urlsToNames[rule.system] ? urlsToNames[rule.system] : rule.system}`,
       '',
-      '',
-      `includes codes from code system ${urlsToNames[rule.system] ? urlsToNames[rule.system] : rule.system}`
+      ''
     ]);
     codeSystems.add(system);
   }
@@ -452,9 +453,9 @@ function fillValueSetLines(vs, valueSetLines, valueSetDetailsLines) {
     valueSetDetailsLines.push([
       vs.identifier.name,
       system,
+      `excludes codes descending from ${rule.code.code} | ${rule.code.display}`,
       '',
-      '',
-      `excludes codes descending from ${rule.code.code} | ${rule.code.display}`
+      ''
     ]);
     codeSystems.add(system);
   }
@@ -474,7 +475,7 @@ function generateDDtoPath(specs, config, outputPath) {
   'Terminology Binding', 'Code System', 'Code', 'Code Description', 'Value Set', 'Value Set Binding', 'Units']];
   const profileLines = [['Profile Name', 'Profile Description']];
   const valueSetLines = [['Value Set', 'Description', 'Code Systems']];
-  const valueSetDetailsLines = [['Value Set', 'Code System', 'Code', 'Code Description', 'Logical Definition']];
+  const valueSetDetailsLines = [['Value Set', 'Code System', 'Logical Definition', 'Code', 'Code Description']];
   for (const de of specs.dataElements.all) {
     fillElementLines(dataElementLines, profileLines, vsMap, de, specs, config);
   }


### PR DESCRIPTION
The Data Elements worksheet has been restructured to include more detailed information about terminology bindings. When an element is constrained to a specific code, the code, code system, and code description are shown, and "Fixed Code" is shown as the terminology binding. When an element is constrained to a value set, "Value Set" is shown as the terminology binding. When neither of these cases apply, the terminology binding field is empty.

In the Value Set Details worksheet, the output of logical definitions and code descriptions for value sets has changed. The code and code description fields are used only for enumerated value sets.

As an additional fix: value set descriptions no longer contain extraneous quotation marks.