### PR TITLE
Use obf.datatype namespace for units

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -24,7 +24,7 @@ const urlsToNames = {
   'http://www.nationsonline.org/oneworld/country_code_list': 'CC',
   'https://www.ncbi.nlm.nih.gov/refseq': 'NCBI Reference Sequence Database',
   'http://ncimeta.nci.nih.gov': 'NCI Metathesaurus',
-  'http://uts.nlm.nih.gov/metathesaurus': 'NCI Metatheasurus',
+  'http://uts.nlm.nih.gov/metathesaurus': 'NCI Metathesaurus',
   'https://ncit.nci.nih.gov': 'NCI Thesaurus',
   'https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus': 'NCI Thesaurus',
   'http://www.nlm.nih.gov/research/umls/rxnorm': 'RxNorm',
@@ -125,7 +125,7 @@ function getUnit(de, path, specs, projectURL) {
   let constraint;
   const constraints = value.constraintsFilter.constraints;
   if (constraints && constraints.length > 0) {
-    constraint = constraints.find(c => !c.onValue && c.path.some(e => e.equals(new Identifier('shr.core', 'Units'))));
+    constraint = constraints.find(c => !c.onValue && c.path.some(e => e.equals(new Identifier('obf.datatype', 'Units'))));
   }
   if (!constraint) {
     // It may be on the value...
@@ -134,6 +134,7 @@ function getUnit(de, path, specs, projectURL) {
   if (constraint) {
     let units = '';
     if (constraint.code) {
+      logger.info('grease');
       units = constraint.code.display ? `"${constraint.code.display}"` : constraint.code.code;
     } else if (constraint.valueSet) {
       units = constraint.valueSet.startsWith(projectURL) ? constraint.valueSet.slice(constraint.valueSet.lastIndexOf('/')+1) : constraint.valueSet;
@@ -160,7 +161,7 @@ function getConstraintOnValue(value, dataElements, useCase) {
           return newVsConstraints.find(c => !c.onValue && c.path.length === 0);
         case 'unit':
           const newConstraints = newValue.constraintsFilter.constraints;
-          return newConstraints.find(c => !c.onValue && c.path.some(e => e.equals('shr.core', 'Units')));
+          return newConstraints.find(c => !c.onValue && c.path.some(e => e.equals('obf.datatype', 'Units')));
         default:
           break;
       }

--- a/lib/export.js
+++ b/lib/export.js
@@ -134,7 +134,6 @@ function getUnit(de, path, specs, projectURL) {
   if (constraint) {
     let units = '';
     if (constraint.code) {
-      logger.info('grease');
       units = constraint.code.display ? `"${constraint.code.display}"` : constraint.code.code;
     } else if (constraint.valueSet) {
       units = constraint.valueSet.startsWith(projectURL) ? constraint.valueSet.slice(constraint.valueSet.lastIndexOf('/')+1) : constraint.valueSet;


### PR DESCRIPTION
When checking a data element for units, look for a constraint that contains an identifier for Units in the obf.datatype namespace on its path.
Fix spelling of NCI Metathesaurus.
