### PR TITLE
Remove namespace header from valuesets in data elements tab

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -114,8 +114,8 @@ function getVsInfo(de, path, specs, projectURL) {
     constraint = getConstraintOnValue(value, specs.dataElements, 'vsInfo');
   }
   if (constraint) {
-    const url = constraint.valueSet.startsWith(projectURL) ? constraint.valueSet.slice(constraint.valueSet.lastIndexOf('/')+1) : constraint.valueSet;
     const vs = specs.valueSets.findByURL(constraint.valueSet);
+    const url = (constraint.valueSet.startsWith(projectURL) && vs) ? vs.identifier.name : constraint.valueSet;
     return { url, strength: constraint.bindingStrength, vs };
   }
 }


### PR DESCRIPTION
Addresses https://standardhealthrecord.atlassian.net/browse/MCODE-91

Very simple fix to make the data element tab consistent with both value set tabs.

To test it, just make sure that the value set names in the data elements tab appear like they do in the other tabs!